### PR TITLE
Feat/cache closest nodes

### DIFF
--- a/src/rpc/closest.rs
+++ b/src/rpc/closest.rs
@@ -1,0 +1,29 @@
+use std::time::{Duration, Instant};
+
+use crate::Node;
+
+use super::{query::Query, server::ROTATE_INTERVAL};
+
+/// Similar to the token rotation interval described in BEP_0005
+const CLOSEST_NODES_EXPIRY_DURATION: Duration = ROTATE_INTERVAL;
+
+#[derive(Debug)]
+pub struct ClosestNodes {
+    pub(crate) nodes: Vec<Node>,
+    last_seen: Instant,
+}
+
+impl ClosestNodes {
+    pub fn expired(&self) -> bool {
+        Instant::now().duration_since(self.last_seen) > CLOSEST_NODES_EXPIRY_DURATION
+    }
+}
+
+impl From<&Query> for ClosestNodes {
+    fn from(query: &Query) -> Self {
+        ClosestNodes {
+            nodes: query.closest(),
+            last_seen: Instant::now(),
+        }
+    }
+}

--- a/src/rpc/closest.rs
+++ b/src/rpc/closest.rs
@@ -2,7 +2,7 @@ use std::time::{Duration, Instant};
 
 use crate::Node;
 
-use super::{query::Query, server::ROTATE_INTERVAL};
+use super::server::ROTATE_INTERVAL;
 
 /// Similar to the token rotation interval described in BEP_0005
 const CLOSEST_NODES_EXPIRY_DURATION: Duration = ROTATE_INTERVAL;
@@ -14,16 +14,14 @@ pub struct ClosestNodes {
 }
 
 impl ClosestNodes {
-    pub fn expired(&self) -> bool {
-        Instant::now().duration_since(self.last_seen) > CLOSEST_NODES_EXPIRY_DURATION
-    }
-}
-
-impl From<&Query> for ClosestNodes {
-    fn from(query: &Query) -> Self {
-        ClosestNodes {
-            nodes: query.closest(),
+    pub fn new(nodes: Vec<Node>) -> Self {
+        Self {
+            nodes,
             last_seen: Instant::now(),
         }
+    }
+
+    pub fn expired(&self) -> bool {
+        Instant::now().duration_since(self.last_seen) > CLOSEST_NODES_EXPIRY_DURATION
     }
 }

--- a/src/rpc/query.rs
+++ b/src/rpc/query.rs
@@ -56,6 +56,10 @@ impl Query {
         &self.request
     }
 
+    pub fn closest(&self) -> Vec<Node> {
+        self.with_token.closest(&self.target)
+    }
+
     // === Public Methods ===
 
     /// Add a sender to the query and send all replies we found so far to it.

--- a/src/rpc/server/tokens.rs
+++ b/src/rpc/server/tokens.rs
@@ -12,7 +12,7 @@ use tracing::trace;
 
 const SECRET_SIZE: usize = 20;
 const TOKEN_SIZE: usize = 4;
-const ROTATE_INTERVAL: Duration = Duration::from_secs(60 * 5);
+pub const ROTATE_INTERVAL: Duration = Duration::from_secs(60 * 5);
 const CASTAGNOLI: Crc<u32> = Crc::<u32>::new(&CRC_32_ISCSI);
 
 pub struct Tokens {


### PR DESCRIPTION
By caching the closest nodes from previous queries for 5 minutes, subsequent queries are much likely to find the new closest nodes with fewer hops and lower latency.

This also opens the door for following breaking change where StoreQueries can put directly to these cached closest nodes, which should avoid the internal blocking iterator inside methods like `put_mutable` making all methods returning flume::receiver instead.