### PR TITLE
feat: servers return NoMoreRecentValue response

### DIFF
--- a/examples/get_mutable.rs
+++ b/examples/get_mutable.rs
@@ -42,7 +42,7 @@ fn lookup(dht: &Dht, public_key: VerifyingKey) {
     let mut count = 0;
 
     println!("Streaming mutable items:");
-    for item in dht.get_mutable(public_key.as_bytes(), None).unwrap() {
+    for item in dht.get_mutable(public_key.as_bytes(), None, None).unwrap() {
         count += 1;
 
         if !first {

--- a/src/messages/internal.rs
+++ b/src/messages/internal.rs
@@ -96,6 +96,11 @@ pub enum DHTResponseSpecific {
         arguments: DHTGetMutableResponseArguments,
     },
 
+    NoMoreRecentValue {
+        #[serde(rename = "r")]
+        arguments: DHTNoMoreRecentValueResponseArguments,
+    },
+
     GetImmutable {
         #[serde(rename = "r")]
         arguments: DHTGetImmutableResponseArguments,
@@ -257,6 +262,21 @@ pub struct DHTGetImmutableResponseArguments {
 
     #[serde(with = "serde_bytes")]
     pub v: Vec<u8>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct DHTNoMoreRecentValueResponseArguments {
+    #[serde(with = "serde_bytes")]
+    pub id: Vec<u8>,
+
+    #[serde(with = "serde_bytes")]
+    pub token: Vec<u8>,
+
+    #[serde(with = "serde_bytes")]
+    #[serde(default)]
+    pub nodes: Option<Vec<u8>>,
+
+    pub seq: i64,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -19,8 +19,9 @@ use crate::common::{
 };
 use crate::messages::{
     FindNodeRequestArguments, GetImmutableResponseArguments, GetMutableResponseArguments,
-    GetPeersResponseArguments, GetValueRequestArguments, Message, MessageType, PutRequestSpecific,
-    RequestSpecific, RequestTypeSpecific, ResponseSpecific,
+    GetPeersResponseArguments, GetValueRequestArguments, Message, MessageType,
+    NoMoreRecentValueResponseArguments, PutRequestSpecific, RequestSpecific, RequestTypeSpecific,
+    ResponseSpecific,
 };
 
 use crate::Result;
@@ -422,6 +423,23 @@ impl Rpc {
                             "Invalid mutable record"
                         );
                     }
+                }
+                MessageType::Response(ResponseSpecific::NoMoreRecentValue(
+                    NoMoreRecentValueResponseArguments {
+                        seq, responder_id, ..
+                    },
+                )) => {
+                    debug!(
+                        target= ?query.target,
+                        salt= ?match query.request.request_type.clone() {
+                            RequestTypeSpecific::GetValue(args) => args.salt,
+                            _ => None,
+                        },
+                        ?seq,
+                        ?from,
+                        ?responder_id,
+                        "No more recent mutable value"
+                    );
                 }
                 // Ping response is already handled in add_node()
                 // FindNode response is already handled in query.add_candidate()


### PR DESCRIPTION
Frome [BEP_0044](https://www.bittorrent.org/beps/bep_0044.html):

> The optional seq field specifies that an item's value should only be sent if its sequence number is greater than the given value. If a stored item exists but its sequence number is less than or equal to the seq field then the k, v, and sig fields SHOULD be omitted from the response.