### PR TITLE
added fix for Instant::now() subtraction overflow

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -97,7 +97,7 @@ impl Rpc {
             put_queries: HashMap::new(),
             closest_nodes: LruCache::new(NonZeroUsize::new(MAX_CACHED_BUCKETS).unwrap()),
 
-            last_table_refresh: Instant::now() - REFRESH_TABLE_INTERVAL,
+            last_table_refresh: Instant::now().checked_sub(REFRESH_TABLE_INTERVAL).unwrap_or_else(Instant::now),
             last_table_ping: Instant::now(),
         })
     }


### PR DESCRIPTION
under the case that an individual runs a piece of software depending on this crate, the runtime will panic due to the Instant being smaller than the duration since the UNIX epoch.

You can reproduce this bug by simply restarting your PC (whether its linux or windows, i observed it occurring on both) and then trying to run an application depending on this crate.