### PR TITLE
support adaptive request timeout and remove manual configuration

### DIFF
--- a/src/dht.rs
+++ b/src/dht.rs
@@ -4,7 +4,6 @@ use std::{
     collections::HashMap,
     net::{Ipv4Addr, SocketAddrV4, ToSocketAddrs},
     thread,
-    time::Duration,
 };
 
 use flume::{Receiver, Sender, TryRecvError};
@@ -92,19 +91,6 @@ impl DhtBuilder {
     /// Defaults to depending on suggestions from responding nodes.
     pub fn public_ip(&mut self, public_ip: Ipv4Addr) -> &mut Self {
         self.0.public_ip = Some(public_ip);
-
-        self
-    }
-
-    /// UDP socket request timeout duration.
-    ///
-    /// The longer this duration is, the longer queries take until they are deemeed "done".
-    /// The shortet this duration is, the more responses from busy nodes we miss out on,
-    /// which affects the accuracy of queries trying to find closest nodes to a target.
-    ///
-    /// Defaults to [crate::DEFAULT_REQUEST_TIMEOUT]
-    pub fn request_timeout(&mut self, request_timeout: Duration) -> &mut Self {
-        self.0.request_timeout = request_timeout;
 
         self
     }
@@ -719,7 +705,7 @@ pub enum PutMutableError {
 
 #[cfg(test)]
 mod test {
-    use std::str::FromStr;
+    use std::{str::FromStr, time::Duration};
 
     use ed25519_dalek::SigningKey;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub use dht::{Dht, DhtBuilder, Testnet};
 pub use rpc::{
     messages::{MessageType, PutRequestSpecific, RequestSpecific},
     server::{RequestFilter, ServerSettings, MAX_INFO_HASHES, MAX_PEERS, MAX_VALUES},
-    ClosestNodes, DEFAULT_REQUEST_TIMEOUT,
+    ClosestNodes,
 };
 
 pub use ed25519_dalek::SigningKey;

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -37,7 +37,6 @@ pub use closest_nodes::ClosestNodes;
 pub use info::Info;
 pub use iterative_query::GetRequestSpecific;
 pub use put_query::{ConcurrencyError, PutError, PutQueryError};
-pub use socket::DEFAULT_REQUEST_TIMEOUT;
 
 pub const DEFAULT_BOOTSTRAP_NODES: [&str; 4] = [
     "router.bittorrent.com:6881",

--- a/src/rpc/config.rs
+++ b/src/rpc/config.rs
@@ -1,11 +1,8 @@
-use std::{
-    net::{Ipv4Addr, SocketAddrV4},
-    time::Duration,
-};
+use std::net::{Ipv4Addr, SocketAddrV4};
 
-use super::{ServerSettings, DEFAULT_REQUEST_TIMEOUT};
+use super::ServerSettings;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 /// Dht Configurations
 pub struct Config {
     /// Bootstrap nodes
@@ -16,14 +13,6 @@ pub struct Config {
     ///
     /// Defaults to None
     pub port: Option<u16>,
-    /// UDP socket request timeout duration.
-    ///
-    /// The longer this duration is, the longer queries take until they are deemeed "done".
-    /// The shortet this duration is, the more responses from busy nodes we miss out on,
-    /// which affects the accuracy of queries trying to find closest nodes to a target.
-    ///
-    /// Defaults to [DEFAULT_REQUEST_TIMEOUT]
-    pub request_timeout: Duration,
     /// Server to respond to incoming Requests
     pub server_settings: ServerSettings,
     /// Whether or not to start in server mode from the get go.
@@ -35,17 +24,4 @@ pub struct Config {
     ///
     /// Defaults to None, where we depend on suggestions from responding nodes.
     pub public_ip: Option<Ipv4Addr>,
-}
-
-impl Default for Config {
-    fn default() -> Self {
-        Self {
-            bootstrap: None,
-            port: None,
-            request_timeout: DEFAULT_REQUEST_TIMEOUT,
-            server_settings: Default::default(),
-            server_mode: false,
-            public_ip: None,
-        }
-    }
 }


### PR DESCRIPTION
closes #17 

This a breaking change (needs major version) because it changes how the `request_timeout` method in the builder affect the behavior of the node.

This reduces the time we wait for exhausting queries and run tests, because it keeps track of the usual time a roundtrip takes, and uses that to judge whether or not a request has timed out.

The usual estimation on my machine is around half a second, a bit less sometimes, which is not too far from the default 2 seconds, but it allows us to remove the manual configuration, which is one less thing to get wrong.

All examples and dht size measurements seem to work just fine, and cpu usage is as usual.